### PR TITLE
feat(create-plugin): add google-nodejs-typescript template

### DIFF
--- a/docs/providers/google/cli-reference/create.md
+++ b/docs/providers/google/cli-reference/create.md
@@ -43,6 +43,7 @@ To see a list of available templates run `serverless create --help`
 Most commonly used templates:
 
 - google-nodejs
+- google-nodejs-typescript
 - google-go
 - google-python
 

--- a/lib/plugins/create/templates/google-nodejs-typescript/.gitignore
+++ b/lib/plugins/create/templates/google-nodejs-typescript/.gitignore
@@ -1,0 +1,11 @@
+# package directories
+node_modules
+
+# Serverless directories
+.serverless
+
+# Webpack directories
+.webpack
+
+# Typescript output dir
+dist

--- a/lib/plugins/create/templates/google-nodejs-typescript/.nvmrc
+++ b/lib/plugins/create/templates/google-nodejs-typescript/.nvmrc
@@ -1,0 +1,1 @@
+lts/fermium

--- a/lib/plugins/create/templates/google-nodejs-typescript/README.md
+++ b/lib/plugins/create/templates/google-nodejs-typescript/README.md
@@ -1,0 +1,51 @@
+# Serverless - Google Node.js Typescript
+
+This project has been generated using the `google-nodejs-typescript` template from the [Serverless framework](https://www.serverless.com/).
+
+For detailed instructions, please refer to the [documentation](https://www.serverless.com/framework/docs/providers/google/).
+
+## Installation/deployment instructions
+
+Depending on your preferred package manager, follow the instructions below to deploy your project.
+
+> **Requirements**: NodeJS `lts/fermium (v.14.15.0)`. If you're using [nvm](https://github.com/nvm-sh/nvm), run `nvm use` to ensure you're using the same Node version in local and in your cloud function's runtime.
+
+### Setup your google project
+
+1. Go to the [API dashboard](https://console.cloud.google.com/apis/dashboard), select your project and enable the following APIs (if not already enabled):
+
+   - Cloud Functions API
+   - Cloud Deployment Manager V2 API
+   - Cloud Build API
+   - Cloud Storage
+   - Cloud Logging API
+
+2. Replace `<your-gcp-project-id>` with your project id in `serverles.ts`
+
+### Authenticate
+
+Follow [the authentication doc](https://www.serverless.com/framework/docs/providers/google/guide/credentials/).
+
+**TL;DR**
+
+```shell
+gcloud auth application-default login
+```
+
+### Install the dependencies
+
+```shell
+# with npm
+npm i
+# or yarn
+yarn
+```
+
+### Deploy
+
+```shell
+# with npm
+npm run deploy
+# or yarn
+yarn deploy
+```

--- a/lib/plugins/create/templates/google-nodejs-typescript/index.ts
+++ b/lib/plugins/create/templates/google-nodejs-typescript/index.ts
@@ -1,0 +1,2 @@
+export { eventHello } from '@functions/eventHello/handler';
+export { httpHello } from '@functions/httpHello/handler';

--- a/lib/plugins/create/templates/google-nodejs-typescript/package.json
+++ b/lib/plugins/create/templates/google-nodejs-typescript/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "google-nodejs-typescript",
+  "version": "1.0.0",
+  "description": "Serverless google-nodejs-typescript template",
+  "main": "serverless.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "deploy": "sls deploy"
+  },
+  "engines": {
+    "node": ">=14.15.0"
+  },
+  "devDependencies": {
+    "@serverless/typescript": "^2.23.0",
+    "@types/express": "^4.17.11",
+    "@types/node": "^14.14.25",
+    "express": "^4.17.1",
+    "serverless": "^2.23.0",
+    "serverless-google-cloudfunctions": "^4.0.0",
+    "serverless-webpack": "^5.3.5",
+    "ts-loader": "^8.0.15",
+    "ts-node": "^9.1.1",
+    "tsconfig-paths": "^3.9.0",
+    "tsconfig-paths-webpack-plugin": "^3.3.0",
+    "typescript": "^4.1.3",
+    "webpack": "^5.20.2",
+    "webpack-node-externals": "^2.5.2"
+  },
+  "author": "Corentin Doué",
+  "license": "MIT"
+}

--- a/lib/plugins/create/templates/google-nodejs-typescript/serverless.ts
+++ b/lib/plugins/create/templates/google-nodejs-typescript/serverless.ts
@@ -1,0 +1,22 @@
+import { functions } from '@functions/config';
+
+const serverlessConfiguration = {
+  service: 'gcf-nodejs-typescript-template', // NOTE: Don't put the word "google" in here
+  frameworkVersion: '2',
+  custom: {
+    webpack: {
+      webpackConfig: './webpack.config.js',
+      includeModules: true,
+    },
+  },
+  plugins: ['serverless-google-cloudfunctions', 'serverless-webpack'],
+  provider: {
+    name: 'google',
+    runtime: 'nodejs14',
+    region: 'europe-west1',
+    project: '<your-gcp-project-id>',
+  },
+  functions,
+};
+
+module.exports = serverlessConfiguration;

--- a/lib/plugins/create/templates/google-nodejs-typescript/src/functions/config.ts
+++ b/lib/plugins/create/templates/google-nodejs-typescript/src/functions/config.ts
@@ -1,0 +1,7 @@
+// import { eventHello } from './eventHello/config';
+import { httpHello } from './httpHello/config';
+
+export const functions = {
+  // eventHello, // cf ./eventHello/config.ts
+  httpHello
+};

--- a/lib/plugins/create/templates/google-nodejs-typescript/src/functions/eventHello/config.ts
+++ b/lib/plugins/create/templates/google-nodejs-typescript/src/functions/eventHello/config.ts
@@ -1,0 +1,16 @@
+// This function is not deployed by default because the topic does not exist
+// 1. Create a Topic
+// 2. Replace events[0].event.resource with the topic name
+// 3. Uncomment the eventHello import and declaration in src/functions/config.ts
+
+export const eventHello = {
+  handler: 'eventHello',
+  events: [
+    {
+      event: {
+        eventType: 'providers/cloud.pubsub/eventTypes/topic.publish',
+        resource: 'projects/<your-gcp-project-id>/topics/<your-topic-name>', // This is the name of the topic
+      },
+    },
+  ],
+};

--- a/lib/plugins/create/templates/google-nodejs-typescript/src/functions/eventHello/handler.ts
+++ b/lib/plugins/create/templates/google-nodejs-typescript/src/functions/eventHello/handler.ts
@@ -1,0 +1,13 @@
+import { logger } from '@libs/logs';
+import { eventErrorHandler } from '@libs/errorHandler';
+
+type Event = {
+  message: string;
+};
+
+export const eventHello = eventErrorHandler(
+  async (event: Event): Promise<void> => {
+    const { message } = event;
+    logger.log({ message });
+  }
+);

--- a/lib/plugins/create/templates/google-nodejs-typescript/src/functions/httpHello/config.ts
+++ b/lib/plugins/create/templates/google-nodejs-typescript/src/functions/httpHello/config.ts
@@ -1,0 +1,8 @@
+export const httpHello = {
+  handler: 'httpHello',
+  events: [
+    {
+      http: 'hello',
+    },
+  ],
+};

--- a/lib/plugins/create/templates/google-nodejs-typescript/src/functions/httpHello/handler.ts
+++ b/lib/plugins/create/templates/google-nodejs-typescript/src/functions/httpHello/handler.ts
@@ -1,0 +1,19 @@
+import type { Request as ExpressRequest, Response } from 'express';
+import { logger } from '@libs/logs';
+import { httpErrorHandler } from '@libs/errorHandler';
+
+type Body = {
+  message: string;
+};
+type Request = ExpressRequest<Record<string, string>, void, Body>;
+
+export const httpHello = httpErrorHandler(
+  async (req: Request, res: Response): Promise<void> => {
+    const {
+      body: { message },
+    } = req;
+    logger.log({ message });
+
+    res.status(200).send();
+  }
+);

--- a/lib/plugins/create/templates/google-nodejs-typescript/src/libs/errorHandler.ts
+++ b/lib/plugins/create/templates/google-nodejs-typescript/src/libs/errorHandler.ts
@@ -1,0 +1,30 @@
+import type { Request, Response } from 'express';
+import { logger } from '@libs/logs';
+
+type HttpHandler = (req: Request, res: Response) => unknown | Promise<unknown>;
+export const httpErrorHandler = (handler: HttpHandler) => async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  logger.init(req);
+  try {
+    await handler(req, res);
+  } catch (error) {
+    logger.error(error);
+    res.status(500).send();
+  }
+};
+
+type EventHandler<E> = (event: E) => void | Promise<void>;
+
+export const HANDLER_ERROR_MESSAGE = 'An error occurred during the handle of the event';
+export const eventErrorHandler = <E>(handler: EventHandler<E>) => async (
+  event: E
+): Promise<void> => {
+  try {
+    await handler(event);
+  } catch (error) {
+    logger.error(error);
+    throw new Error(HANDLER_ERROR_MESSAGE);
+  }
+};

--- a/lib/plugins/create/templates/google-nodejs-typescript/src/libs/logs.ts
+++ b/lib/plugins/create/templates/google-nodejs-typescript/src/libs/logs.ts
@@ -1,0 +1,72 @@
+import type { Request } from 'express';
+
+export enum GCPLogEntrySeverity {
+  DEFAULT = 'DEFAULT', // (0) The log entry has no assigned severity level.
+  DEBUG = 'DEBUG', // (100) Debug or trace information.
+  INFO = 'INFO', // (200) Routine information, such as ongoing status or performance.
+  NOTICE = 'NOTICE', // (300) Normal but significant events, such as start up, shut down, or a configuration change.
+  WARNING = 'WARNING', // (400) Warning events might cause problems.
+  ERROR = 'ERROR', // (500) Error events are likely to cause problems.
+  CRITICAL = 'CRITICAL', // (600) Critical events cause more severe problems or outages.
+  ALERT = 'ALERT', // (700) A person must take an action immediately.
+  EMERGENCY = 'EMERGENCY', // (800) One or more systems are unusable.
+}
+type JSONPayload = {
+  message?: string;
+  [key: string]: Record<string, unknown> | string | undefined;
+};
+type Payload = string | JSONPayload;
+export const JSON_PAYLOAD_MESSAGE =
+  'This log contains a JSON payload, use GCP log explorer to see it';
+
+class Logger {
+  req: Request | undefined;
+
+  init = (req: Request) => {
+    this.req = req;
+  };
+
+  log = (payload: Payload): void => {
+    const entry = this.logEntry();
+    let message: string;
+    let jsonPayload: JSONPayload | undefined;
+    if (typeof payload === 'object') {
+      message = payload.message ?? JSON_PAYLOAD_MESSAGE;
+      jsonPayload = payload;
+    } else {
+      message = payload;
+    }
+    console.log(JSON.stringify(entry(GCPLogEntrySeverity.INFO, message, jsonPayload)));
+  };
+
+  error = (error: Error): void => {
+    const entry = this.logEntry();
+    const { message, stack } = error;
+
+    console.log(JSON.stringify(entry(GCPLogEntrySeverity.ERROR, message, { stack })));
+  };
+
+  logEntry = () => (
+    severity: GCPLogEntrySeverity,
+    message: string,
+    jsonPayload: JSONPayload = {}
+  ): Record<string, unknown> => ({
+    severity,
+    message,
+    ...jsonPayload,
+    ...this.getCloudTrace(),
+  });
+
+  getCloudTrace = (): Record<string, string> => {
+    const project = process.env.GCP_PROJECT; // GCP_PROJECT is always set by the runner of the cloud function
+
+    const traceHeader = this.req?.header('X-Cloud-Trace-Context');
+    if (traceHeader !== undefined && project !== undefined) {
+      const [trace] = traceHeader.split('/');
+      return { 'logging.googleapis.com/trace': `projects/${project}/traces/${trace}` };
+    }
+    return {};
+  };
+}
+
+export const logger = new Logger();

--- a/lib/plugins/create/templates/google-nodejs-typescript/tsconfig.json
+++ b/lib/plugins/create/templates/google-nodejs-typescript/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.paths.json",
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "removeComments": true,
+    "sourceMap": true,
+    "target": "ES2020",
+    "outDir": "dist"
+  },
+  "include": ["**/*.ts", "serverless.ts"],
+  "exclude": ["node_modules/**/*", ".serverless/**/*", ".webpack/**/*", ".vscode/**/*"],
+  "ts-node": {
+    "require": ["tsconfig-paths/register"]
+  }
+}

--- a/lib/plugins/create/templates/google-nodejs-typescript/tsconfig.paths.json
+++ b/lib/plugins/create/templates/google-nodejs-typescript/tsconfig.paths.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@functions/*": ["src/functions/*"],
+      "@libs/*": ["src/libs/*"]
+    }
+  }
+}

--- a/lib/plugins/create/templates/google-nodejs-typescript/webpack.config.js
+++ b/lib/plugins/create/templates/google-nodejs-typescript/webpack.config.js
@@ -1,0 +1,52 @@
+const path = require('path');
+const slsw = require('serverless-webpack');
+const nodeExternals = require('webpack-node-externals');
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+
+module.exports = {
+  context: __dirname,
+  mode: slsw.lib.webpack.isLocal ? 'development' : 'production',
+  entry: 'index.ts',
+  devtool: slsw.lib.webpack.isLocal ? 'eval-cheap-module-source-map' : 'source-map',
+  resolve: {
+    extensions: ['.mjs', '.json', '.ts'],
+    symlinks: false,
+    cacheWithContext: false,
+    plugins: [
+      new TsconfigPathsPlugin({
+        configFile: './tsconfig.paths.json',
+      }),
+    ],
+  },
+  output: {
+    libraryTarget: 'commonjs',
+    path: path.join(__dirname, '.webpack'),
+    filename: 'index.js',
+  },
+  optimization: {
+    concatenateModules: false,
+  },
+  target: 'node',
+  externals: [nodeExternals()],
+  module: {
+    rules: [
+      // all files with a `.ts` or `.tsx` extension will be handled by `ts-loader`
+      {
+        test: /\.(tsx?)$/,
+        loader: 'ts-loader',
+        exclude: [
+          [
+            path.resolve(__dirname, 'node_modules'),
+            path.resolve(__dirname, '.serverless'),
+            path.resolve(__dirname, '.webpack'),
+          ],
+        ],
+        options: {
+          transpileOnly: true,
+          experimentalWatchApi: true,
+        },
+      },
+    ],
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Add `google-nodejs-typescript` template

I'm currently working with Serverless framework and GCP. I use `typescript` and `serverless-google-cloudfunctions` and I suffered of the lack of examples with this stack.

I propose to add a new template based on the `aws-nodejs-typescript` with GCP specificities to provide an example for typescript users who wants to do serverless on GCP.